### PR TITLE
Develop

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModule } from './user/user.module';
 import { ProfileModule } from './profile/profile.module';
 import { OccupationModule } from './occupation/occupation.module';
+import { SkillModule } from './skill/skill.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { OccupationModule } from './occupation/occupation.module';
     UserModule,
     ProfileModule,
     OccupationModule,
+    SkillModule,
   ],
   controllers: [],
   providers: [],

--- a/src/skill/dto/create-skill.dto.ts
+++ b/src/skill/dto/create-skill.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateSkillDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  @MaxLength(255)
+  name: string;
+}

--- a/src/skill/dto/index.ts
+++ b/src/skill/dto/index.ts
@@ -1,0 +1,2 @@
+export { CreateSkillDto } from './create-skill.dto';
+export { UpdateSkillDto } from './update-skill.dto';

--- a/src/skill/dto/update-skill.dto.ts
+++ b/src/skill/dto/update-skill.dto.ts
@@ -1,0 +1,19 @@
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class UpdateSkillDto {
+  @IsNumber()
+  @IsNotEmpty()
+  id: number;
+
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  @MaxLength(255)
+  name: string;
+}

--- a/src/skill/entities/index.ts
+++ b/src/skill/entities/index.ts
@@ -1,0 +1,1 @@
+export { Skill } from './skill.entity';

--- a/src/skill/entities/skill.entity.ts
+++ b/src/skill/entities/skill.entity.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({ name: 'skill' })
+export class Skill {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'name', type: 'varchar', length: 255, unique: true })
+  name: string;
+}

--- a/src/skill/enums/index.ts
+++ b/src/skill/enums/index.ts
@@ -1,0 +1,1 @@
+export { LevelSkill } from './level-skill.enum';

--- a/src/skill/enums/level-skill.enum.ts
+++ b/src/skill/enums/level-skill.enum.ts
@@ -1,0 +1,6 @@
+export enum LevelSkill {
+  INTERMEDIATE = 'INTERMEDIATE',
+  BASIC = 'BASIC',
+  ADVANCED = 'ADVANCED',
+  EXPERT = 'EXPERT',
+}

--- a/src/skill/skill.controller.ts
+++ b/src/skill/skill.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller,
+  Body,
+  Post,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  ParseIntPipe,
+  HttpCode,
+} from '@nestjs/common';
+import { CreateSkillDto, UpdateSkillDto } from './dto';
+import { SkillService } from './skill.service';
+import { Skill } from './entities';
+
+@Controller('v1/skill')
+export class SkillController {
+  constructor(private readonly skillService: SkillService) {}
+
+  @Post()
+  public async createSkill(@Body() skill: CreateSkillDto): Promise<Skill> {
+    return await this.skillService.create(skill);
+  }
+
+  @Get()
+  public async getAllSkills(): Promise<Skill[]> {
+    return await this.skillService.findAll();
+  }
+
+  @Patch()
+  public async updateOneSkill(
+    @Body()
+    skill: UpdateSkillDto,
+  ): Promise<Skill> {
+    return await this.skillService.update(skill);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  public async deleteOneSkill(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<Skill> {
+    return await this.skillService.delete(id);
+  }
+}

--- a/src/skill/skill.module.ts
+++ b/src/skill/skill.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Skill } from './entities';
+import { SkillController } from './skill.controller';
+import { SkillService } from './skill.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Skill])],
+  controllers: [SkillController],
+  providers: [SkillService],
+  exports: [],
+})
+export class SkillModule {}

--- a/src/skill/skill.service.ts
+++ b/src/skill/skill.service.ts
@@ -1,0 +1,64 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Skill } from './entities';
+import { Repository } from 'typeorm';
+import { CreateSkillDto, UpdateSkillDto } from './dto';
+
+@Injectable()
+export class SkillService {
+  constructor(
+    @InjectRepository(Skill)
+    private readonly skillRepository: Repository<Skill>,
+  ) {}
+
+  public async findAll(): Promise<Skill[]> {
+    return await this.skillRepository.find();
+  }
+
+  public async create(skill: CreateSkillDto): Promise<Skill> {
+    const skillExists = await this.skillRepository.findOneBy({
+      name: skill.name,
+    });
+
+    if (skillExists) {
+      throw new ConflictException(`The skill ${skill.name} already exists`);
+    }
+
+    const newSkill = this.skillRepository.create(skill);
+    return this.skillRepository.save(newSkill);
+  }
+
+  public async update(skill: UpdateSkillDto): Promise<Skill> {
+    const skillExists = await this.skillRepository.findOneBy({ id: skill.id });
+
+    if (!skillExists) {
+      throw new NotFoundException('Skill not found :(');
+    }
+
+    await this.skillRepository.update(skill.id, skill);
+    return await this.skillRepository.findOneBy({ id: skill.id });
+  }
+
+  public async delete(id: number): Promise<Skill> {
+    const skillExists = await this.skillRepository.findOneBy({ id });
+
+    if (!skillExists) {
+      throw new NotFoundException('Skill not found :(');
+    }
+
+    const result = await this.skillRepository.delete(id);
+
+    if (result.affected === 0) {
+      throw new ServiceUnavailableException(
+        'Something went wrong, try it later',
+      );
+    }
+
+    return skillExists;
+  }
+}


### PR DESCRIPTION
Added the basic CRUD for the Skill entity:
- [x] added the module, controller and service files for Skill entity
- [x] added skill.entity with annotations and constraints of typeorm
- [x] added the create-skill.dto with class-validations in the columns
- [x] added index files for the classes exports into the /enums /entities and /dto folders
- [x] added the feature basic CRUD with the Skill entity with it's services functions and routes controller   